### PR TITLE
improving the display of the total KP amount.

### DIFF
--- a/KillproofUI.h
+++ b/KillproofUI.h
@@ -44,10 +44,9 @@ protected:
 
 private:
 	static void openInBrowser(const char* username);
-	bool drawRow(const Alignment& alignment, const SYSTEMTIME* joinTime, const char* username, const char* characterName, const char* killproofId, const std::atomic<LoadingStatus>& status,
-	             kpFunction killproofsFun, kpFunction coffersFun, kpFunction kpOverallFun, bool treeNode, bool isCommander = false);
-	void drawTextColumn(bool* open, const char* text, const char* username, const std::atomic<LoadingStatus>& status, bool treeNode, bool first = false, bool
-	                    isCommander = false);
+	template<bool isLinkedAccount>
+	bool drawRow(const Alignment& alignment, const Player& player, bool treeNode);
+	void drawTextRow(bool* open, const char* text, const char* username, const std::atomic<LoadingStatus>& status, bool treeNode, bool first, bool isCommander);
 	void newRow();
 
 	char userAddBuf[1024]{};


### PR DESCRIPTION
Removed the Overall row and instead merged it with the row of the current amount. If folded it will display the total amount and if you unfold the treenode it will display its Kp amount and in braces the total amount.
Also reduced the draws function signature as it seems to be cleaner to just pass the player reference. Also made it a template function to constexpr distinguish between the current and a linked account